### PR TITLE
Footer no longer renders over registration component

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 export default function Footer() {
   return (
-    <nav className="absolute font-['Poppins'] font-normal text-sm bottom-0 ml-10 mb-8 leading-10">
+    <nav className="font-['Poppins'] font-normal text-sm bottom-0 ml-10 mb-8 mt-auto leading-10">
       <ul>
         <li>
           <Link to="/about">about</Link>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -6,10 +6,10 @@ export default function Layout() {
   return (
     <>
       <Header />
-      <Footer />
-
       {/* An <Outlet> renders the active route component, such as <Home /> or <Contact /> */}
       <Outlet />
+
+      <Footer />
     </>
   );
 }


### PR DESCRIPTION
Issue: Footer was rendering over the registration component
Solution: Replaced absolute styling with margin-top: auto on the nav component, moved Footer component under Outlet in Layout
Reviewed by: Clarissa/Lilly
