### PR TITLE
Fix event price

### DIFF
--- a/packages/backend/src/event/event-controller.ts
+++ b/packages/backend/src/event/event-controller.ts
@@ -154,6 +154,7 @@ export const createEvent = async (req: Request, res: Response) => {
         eventLocation: req.body.eventLocation,
         eventTime: new Date(req.body.eventTime),
         stripeProductId: productId,
+        eventPrice: priceFloat,
       });
       await event.save();
       res.status(201).json(event);

--- a/packages/backend/src/event/event-controller.ts
+++ b/packages/backend/src/event/event-controller.ts
@@ -110,8 +110,22 @@ export const createEvent = async (req: Request, res: Response) => {
       req.body.eventTitle &&
       req.body.eventDescription &&
       req.body.eventLocation &&
-      req.body.eventTime
+      req.body.eventTime &&
+      req.body.eventPrice
     ) {
+      // Specify price in terms of dollars (e.g. 4 means $4.00, 4.5 means $4.50)
+      // Convert to string to float
+      let priceFloat = parseFloat(req.body.eventPrice);
+      let priceCents = 0;
+      
+      if (!isNaN(priceFloat)) {
+        priceCents = Math.round(priceFloat * 100);
+        console.log("success: " + priceCents);
+      } else {
+        console.log("fail");
+        throw new Error("Please provide valid price (e.g. 4 means $4.00, 4.5 means $4.50)");
+      }
+
       // Create product on stripe for the event
       const stripe = new Stripe(`${process.env.STRIPE_SECRET_KEY}`, {
         apiVersion: "2022-11-15",
@@ -124,7 +138,7 @@ export const createEvent = async (req: Request, res: Response) => {
       const price = await stripe.prices.create({
         product: productId,
         currency: "nzd",
-        unit_amount: 600, // Adjust the price amount in cents (e.g. 600 = $6)
+        unit_amount: priceCents, // Adjust the price amount in cents (e.g. 600 = $6)
       });
       await stripe.products.update(productId, {
         default_price: price.id,

--- a/packages/backend/src/event/event-controller.ts
+++ b/packages/backend/src/event/event-controller.ts
@@ -117,13 +117,15 @@ export const createEvent = async (req: Request, res: Response) => {
       // Convert to string to float
       let priceFloat = parseFloat(req.body.eventPrice);
       let priceCents = 0;
-      
-      if (!isNaN(priceFloat)) {
+
+      if (!isNaN(priceFloat) && priceFloat > 0) {
         priceCents = Math.round(priceFloat * 100);
         console.log("success: " + priceCents);
       } else {
         console.log("fail");
-        throw new Error("Please provide valid price (e.g. 4 means $4.00, 4.5 means $4.50)");
+        throw new Error(
+          "Please provide valid price in dollars (e.g. 4 means $4.00, 4.5 means $4.50)"
+        );
       }
 
       // Create product on stripe for the event

--- a/packages/backend/src/event/event-model.ts
+++ b/packages/backend/src/event/event-model.ts
@@ -27,6 +27,7 @@ interface IEvent {
   eventLocation: string;
   eventTime: Date;
   stripeProductId: string;
+  eventPrice: number;
   users?: RegistrationRecordEvent[];
 }
 
@@ -37,6 +38,7 @@ type EventDocumentProps = {
   eventLocation: string;
   eventTime: Date;
   stripeProductId: string;
+  eventPrice: number;
   users?: Types.DocumentArray<RegistrationRecordEvent>;
 };
 type EventModelType = Model<IEvent, object, EventDocumentProps>;
@@ -47,6 +49,7 @@ const eventSchema = new Schema<IEvent>({
   eventLocation: { type: String, required: true },
   eventTime: { type: Date, required: true },
   stripeProductId: String,
+  eventPrice: Number,
 
   users: [
     new Schema<RegistrationRecordEvent>({

--- a/packages/frontend/src/routes/EventRegister/EventSignupForm.jsx
+++ b/packages/frontend/src/routes/EventRegister/EventSignupForm.jsx
@@ -163,7 +163,9 @@ const Create = () => {
               </div>
               <div className="flex gap-4 align-middle">
                 <AiOutlineDollar size={24} />
-                <p className="my-auto">$6.00 with ASPA membership</p>
+                <p className="my-auto">
+                  ${event.eventPrice.toFixed(2)} with ASPA membership
+                </p>
               </div>
             </div>
 

--- a/packages/frontend/src/routes/dashboard/admin/AdminEvents.jsx
+++ b/packages/frontend/src/routes/dashboard/admin/AdminEvents.jsx
@@ -106,7 +106,9 @@ export default function AdminEvents() {
             <p className="text-gray-400">
               Date: {new Date(event.eventTime).toLocaleDateString()}
             </p>
-            <p className="text-gray-400">Price: $7</p>
+            <p className="text-gray-400">
+              Price: ${event.eventPrice.toFixed(2)}
+            </p>
             <a href={`events/${event._id}`}>
               <FaArrowRight
                 size={18}

--- a/packages/frontend/src/routes/dashboard/admin/AdminNewEvent.jsx
+++ b/packages/frontend/src/routes/dashboard/admin/AdminNewEvent.jsx
@@ -21,6 +21,7 @@ const AdminNewEvent = () => {
       eventTitle: nameRef.current.value,
       eventDescription: descriptionRef.current.value,
       eventLocation: locationRef.current.value,
+      eventPrice: priceRef.current.value,
       eventTime: date.toISOString(),
     };
 


### PR DESCRIPTION
- You now need to specify the price when creating events
- This price will be used to set the stripe product's price and is stored in the event
- Un-hardcoded the event prices in the event-related pages